### PR TITLE
Fix hydration warning

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -20,6 +20,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning={true}
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}


### PR DESCRIPTION
## Summary
- suppress hydration warning on the `<body>` element

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849328f2ae0832bb8a17615918193d7