### PR TITLE
Fix ReactQuill compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "@tiptap/starter-kit": "^2.14.0",
         "lowlight": "^3.3.0",
         "next": "15.3.3",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "react-quill": "^2.0.0"
       },
       "devDependencies": {
@@ -5885,24 +5885,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-5H31pXgGwK6w1nPzl/4kwkpA0Kct50/vOZzHz1BoBPXaG9q4CPGK/c/pX9B1ZDHr6hEMnAkz6x8dOEFYcwHjKA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-bn6JXRQtmPo0d+w/ZlJL8NtCwE+Lg31vA5EVe2WT3YAt4a7zg4YrfOD1KFlViSAG0p0N/fzEQmzsu2xwXUZKDg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "@tiptap/starter-kit": "^2.14.0",
     "lowlight": "^3.3.0",
     "next": "15.3.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-quill": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- downgrade React and ReactDOM dependencies to 18

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684933a9c3e0832b8263b68a7f967c3a